### PR TITLE
feat: add option to treat all trun boxes as version 1

### DIFF
--- a/.github/workflows/github-dev-snap.yaml
+++ b/.github/workflows/github-dev-snap.yaml
@@ -41,6 +41,7 @@ jobs:
           cmake \
             -DCMAKE_BUILD_TYPE="Release" \
             -DBUILD_SHARED_LIBS=1 \
+            -DUSE_WORKAROUND_FOR_TRUN_VERSION_0=1 \
             -S . \
             -B build/
 

--- a/packager/CMakeLists.txt
+++ b/packager/CMakeLists.txt
@@ -51,6 +51,10 @@ else()
   add_compile_options(-Wno-unknown-warning-option)
 endif()
 
+if(USE_WORKAROUND_FOR_TRUN_VERSION_0)
+  add_definitions(-DUSE_WORKAROUND_FOR_TRUN_VERSION_0=1)
+endif()
+
 # Global include paths.
 # Project root, to reference internal headers as packager/foo/bar/...
 include_directories(..)

--- a/packager/media/formats/mp4/box_definitions.cc
+++ b/packager/media/formats/mp4/box_definitions.cc
@@ -2716,6 +2716,13 @@ bool TrackFragmentRun::ReadWriteInternal(BoxBuffer* buffer) {
       RCHECK(buffer->ReadWriteUInt32(&sample_flags[i]));
 
     if (sample_composition_time_offsets_present) {
+      // TODO: MediaLive produces negative composition time offsets in box version 0.
+      // This is a workaround for that.
+      #ifdef USE_WORKAROUND_FOR_TRUN_VERSION_0
+        int32_t sample_offset = sample_composition_time_offsets[i];
+        RCHECK(buffer->ReadWriteInt32(&sample_offset));
+        sample_composition_time_offsets[i] = sample_offset;
+      #else
       if (version == 0) {
         uint32_t sample_offset = sample_composition_time_offsets[i];
         RCHECK(buffer->ReadWriteUInt32(&sample_offset));
@@ -2725,6 +2732,7 @@ bool TrackFragmentRun::ReadWriteInternal(BoxBuffer* buffer) {
         RCHECK(buffer->ReadWriteInt32(&sample_offset));
         sample_composition_time_offsets[i] = sample_offset;
       }
+      #endif
     }
   }
 

--- a/packager/media/formats/mp4/box_definitions.cc
+++ b/packager/media/formats/mp4/box_definitions.cc
@@ -2716,13 +2716,13 @@ bool TrackFragmentRun::ReadWriteInternal(BoxBuffer* buffer) {
       RCHECK(buffer->ReadWriteUInt32(&sample_flags[i]));
 
     if (sample_composition_time_offsets_present) {
-      // TODO: MediaLive produces negative composition time offsets in box version 0.
-      // This is a workaround for that.
-      #ifdef USE_WORKAROUND_FOR_TRUN_VERSION_0
-        int32_t sample_offset = sample_composition_time_offsets[i];
-        RCHECK(buffer->ReadWriteInt32(&sample_offset));
-        sample_composition_time_offsets[i] = sample_offset;
-      #else
+// TODO: MediaLive produces negative composition time offsets in box version 0.
+// This is a workaround for that.
+#ifdef USE_WORKAROUND_FOR_TRUN_VERSION_0
+      int32_t sample_offset = sample_composition_time_offsets[i];
+      RCHECK(buffer->ReadWriteInt32(&sample_offset));
+      sample_composition_time_offsets[i] = sample_offset;
+#else
       if (version == 0) {
         uint32_t sample_offset = sample_composition_time_offsets[i];
         RCHECK(buffer->ReadWriteUInt32(&sample_offset));
@@ -2732,7 +2732,7 @@ bool TrackFragmentRun::ReadWriteInternal(BoxBuffer* buffer) {
         RCHECK(buffer->ReadWriteInt32(&sample_offset));
         sample_composition_time_offsets[i] = sample_offset;
       }
-      #endif
+#endif
     }
   }
 


### PR DESCRIPTION
MediaLive sends out box version 0 `trun` boxes with negative composition time offsets.  This is to workaround that.