### PR TITLE
fix: preserve trex default sample duration

### DIFF
--- a/packager/live_packager_test.cc
+++ b/packager/live_packager_test.cc
@@ -903,13 +903,15 @@ TEST_F(LivePackagerBaseTest, EditListAfterRepackage) {
     const auto& act_edits = act_track.edit.list.edits;
     ASSERT_EQ(exp_edits.size(), act_edits.size());
 
-    const auto& exp_entry = exp_edits.front();
-    const auto& act_entry = act_edits.front();
+    for (size_t j(0); j < exp_edits.size(); ++j) {
+      const auto& exp_entry = exp_edits[j];
+      const auto& act_entry = act_edits[i];
 
-    EXPECT_EQ(exp_entry.media_rate_fraction, act_entry.media_rate_fraction);
-    EXPECT_EQ(exp_entry.media_rate_integer, act_entry.media_rate_integer);
-    EXPECT_EQ(exp_entry.media_time, act_entry.media_time);
-    EXPECT_EQ(exp_entry.segment_duration, act_entry.segment_duration);
+      EXPECT_EQ(exp_entry.media_rate_fraction, act_entry.media_rate_fraction);
+      EXPECT_EQ(exp_entry.media_rate_integer, act_entry.media_rate_integer);
+      EXPECT_EQ(exp_entry.media_time, act_entry.media_time);
+      EXPECT_EQ(exp_entry.segment_duration, act_entry.segment_duration);
+    }
   }
 }
 

--- a/packager/live_packager_test.cc
+++ b/packager/live_packager_test.cc
@@ -296,6 +296,31 @@ class MP4MediaParserTest {
   std::vector<std::shared_ptr<media::mp4::DASHEventMessageBox>> emsg_samples_;
 };
 
+bool GetBox(const Segment& buffer, media::mp4::Box &out) {
+  bool err(true);
+  size_t bytes_to_read(buffer.Size());
+  const uint8_t* data(buffer.Data());
+
+  while (bytes_to_read > 0) {
+    std::unique_ptr<media::mp4::BoxReader> reader(
+        media::mp4::BoxReader::ReadBox(data, bytes_to_read, &err));
+
+    if (err) {
+      return false;
+    }
+
+    if (reader->type() == out.BoxType()) {
+      out.Parse(reader.get());
+      return true;
+    }
+
+    data += reader->size();
+    bytes_to_read -= reader->size();
+  }
+
+  return false;
+}
+
 void CheckVideoInitSegment(const SegmentBuffer& buffer, media::FourCC format) {
   bool err(true);
   size_t bytes_to_read(buffer.Size());
@@ -841,6 +866,50 @@ TEST_F(LivePackagerBaseTest, VerifyPrdDecryptReEncrypt) {
 
     ASSERT_TRUE(decryptor.Crypt(buffer, &decrypted));
     ASSERT_EQ(decrypted, exp_decrypted_segment_buffer);
+  }
+}
+
+TEST_F(LivePackagerBaseTest, EditListAfterRepackage) {
+  std::vector<uint8_t> init_segment_buffer =
+      ReadTestDataFile("encrypted/prd_data/init.mp4");
+  ASSERT_FALSE(init_segment_buffer.empty());
+
+  LiveConfig live_config;
+  live_config.format = LiveConfig::OutputFormat::FMP4;
+  live_config.track_type = LiveConfig::TrackType::VIDEO;
+  live_config.protection_scheme = LiveConfig::EncryptionScheme::CENC;
+  live_config.decryption_key = HexStringToVector(kKeyHex);
+  live_config.decryption_key_id = HexStringToVector(kKeyIdHex);
+  SetupLivePackagerConfig(live_config);
+
+  SegmentData init_seg(init_segment_buffer.data(),
+                      init_segment_buffer.size());
+  SegmentBuffer actual_buf;
+  const auto status = live_packager_->PackageInit(init_seg, actual_buf);
+  ASSERT_EQ(Status::OK, status);
+  ASSERT_GT(actual_buf.Size(), 0);
+
+  media::mp4::Movie exp_moov;
+  ASSERT_TRUE(GetBox(init_seg, exp_moov));
+  media::mp4::Movie act_moov;
+  ASSERT_TRUE(GetBox(actual_buf, act_moov));
+
+  ASSERT_EQ(exp_moov.tracks.size(), act_moov.tracks.size());
+  for (size_t i(0); i < exp_moov.tracks.size(); ++i) {
+    const auto& exp_track = exp_moov.tracks[i];
+    const auto& act_track = act_moov.tracks[i];
+
+    const auto& exp_edits = exp_track.edit.list.edits;
+    const auto& act_edits = act_track.edit.list.edits;
+    ASSERT_EQ(exp_edits.size(), act_edits.size());
+
+    const auto& exp_entry = exp_edits.front();
+    const auto& act_entry = act_edits.front();
+
+    EXPECT_EQ(exp_entry.media_rate_fraction, act_entry.media_rate_fraction);
+    EXPECT_EQ(exp_entry.media_rate_integer, act_entry.media_rate_integer);
+    EXPECT_EQ(exp_entry.media_time, act_entry.media_time);
+    EXPECT_EQ(exp_entry.segment_duration, act_entry.segment_duration);
   }
 }
 

--- a/packager/live_packager_test.cc
+++ b/packager/live_packager_test.cc
@@ -297,7 +297,7 @@ class MP4MediaParserTest {
   std::vector<std::shared_ptr<media::mp4::DASHEventMessageBox>> emsg_samples_;
 };
 
-bool GetBox(const Segment& buffer, media::mp4::Box &out) {
+bool GetBox(const Segment& buffer, media::mp4::Box& out) {
   bool err(true);
   size_t bytes_to_read(buffer.Size());
   const uint8_t* data(buffer.Data());
@@ -883,8 +883,7 @@ TEST_F(LivePackagerBaseTest, EditListAfterRepackage) {
   live_config.decryption_key_id = HexStringToVector(kKeyIdHex);
   SetupLivePackagerConfig(live_config);
 
-  SegmentData init_seg(init_segment_buffer.data(),
-                      init_segment_buffer.size());
+  SegmentData init_seg(init_segment_buffer.data(), init_segment_buffer.size());
   SegmentBuffer actual_buf;
   const auto status = live_packager_->PackageInit(init_seg, actual_buf);
   ASSERT_EQ(Status::OK, status);

--- a/packager/live_packager_test.cc
+++ b/packager/live_packager_test.cc
@@ -870,7 +870,7 @@ TEST_F(LivePackagerBaseTest, VerifyPrdDecryptReEncrypt) {
   }
 }
 
-TEST_F(LivePackagerBaseTest, EditListAfterRepackage) {
+TEST_F(LivePackagerBaseTest, MoovAfterRepackage) {
   std::vector<uint8_t> init_segment_buffer =
       ReadTestDataFile("encrypted/prd_data/init.mp4");
   ASSERT_FALSE(init_segment_buffer.empty());
@@ -900,6 +900,8 @@ TEST_F(LivePackagerBaseTest, EditListAfterRepackage) {
     const auto& act_track = act_moov.tracks[i];
     EXPECT_EQ(exp_track.edit.list.edits, act_track.edit.list.edits);
   }
+
+  EXPECT_EQ(exp_moov.extends.tracks, act_moov.extends.tracks);
 }
 
 TEST_F(LivePackagerBaseTest, EncryptionFailure) {

--- a/packager/live_packager_test.cc
+++ b/packager/live_packager_test.cc
@@ -29,6 +29,7 @@
 #include <packager/media/formats/mp2t/ts_packet.h>
 #include <packager/media/formats/mp2t/ts_section.h>
 #include <packager/media/formats/mp4/box_definitions.h>
+#include <packager/media/formats/mp4/box_definitions_comparison.h>
 #include <packager/media/formats/mp4/box_reader.h>
 #include <packager/media/formats/mp4/mp4_media_parser.h>
 
@@ -898,20 +899,7 @@ TEST_F(LivePackagerBaseTest, EditListAfterRepackage) {
   for (size_t i(0); i < exp_moov.tracks.size(); ++i) {
     const auto& exp_track = exp_moov.tracks[i];
     const auto& act_track = act_moov.tracks[i];
-
-    const auto& exp_edits = exp_track.edit.list.edits;
-    const auto& act_edits = act_track.edit.list.edits;
-    ASSERT_EQ(exp_edits.size(), act_edits.size());
-
-    for (size_t j(0); j < exp_edits.size(); ++j) {
-      const auto& exp_entry = exp_edits[j];
-      const auto& act_entry = act_edits[i];
-
-      EXPECT_EQ(exp_entry.media_rate_fraction, act_entry.media_rate_fraction);
-      EXPECT_EQ(exp_entry.media_rate_integer, act_entry.media_rate_integer);
-      EXPECT_EQ(exp_entry.media_time, act_entry.media_time);
-      EXPECT_EQ(exp_entry.segment_duration, act_entry.segment_duration);
-    }
+    EXPECT_EQ(exp_track.edit.list.edits, act_track.edit.list.edits);
   }
 }
 

--- a/packager/media/base/stream_info.h
+++ b/packager/media/base/stream_info.h
@@ -157,8 +157,8 @@ class StreamInfo {
   // Optional data required for preserving media time when repackaging an
   // init segment alone.
   int64_t media_time_ = 0;
-  // Optional data required for preserving default sample duration when repackaging an
-  // init segment alone.
+  // Optional data required for preserving default sample duration when
+  // repackaging an init segment alone.
   uint32_t default_sample_duration_ = 0;
 
   // Not using DISALLOW_COPY_AND_ASSIGN here intentionally to allow the compiler

--- a/packager/media/base/stream_info.h
+++ b/packager/media/base/stream_info.h
@@ -106,6 +106,7 @@ class StreamInfo {
   const EncryptionConfig& encryption_config() const {
     return encryption_config_;
   }
+  int64_t media_time() const { return media_time_; }
 
   void set_duration(int64_t duration) { duration_ = duration; }
   void set_codec(Codec codec) { codec_ = codec; }
@@ -122,6 +123,9 @@ class StreamInfo {
   }
   void set_encryption_config(const EncryptionConfig& encryption_config) {
     encryption_config_ = encryption_config;
+  }
+  void set_media_time(int64_t media_time) {
+    media_time_ = media_time;
   }
 
  private:
@@ -145,6 +149,10 @@ class StreamInfo {
   // Optional byte data required for some audio/video decoders such as Vorbis
   // codebooks.
   std::vector<uint8_t> codec_config_;
+
+  // Optional data required for preserving edit lists when repackaging an
+  // init segment alone.
+  int64_t media_time_ = 0;
 
   // Not using DISALLOW_COPY_AND_ASSIGN here intentionally to allow the compiler
   // generated copy constructor and assignment operator. Since the extra data is

--- a/packager/media/base/stream_info.h
+++ b/packager/media/base/stream_info.h
@@ -107,6 +107,9 @@ class StreamInfo {
     return encryption_config_;
   }
   int64_t media_time() const { return media_time_; }
+  uint32_t get_default_sample_duration() const {
+    return default_sample_duration_;
+  }
 
   void set_duration(int64_t duration) { duration_ = duration; }
   void set_codec(Codec codec) { codec_ = codec; }
@@ -125,6 +128,9 @@ class StreamInfo {
     encryption_config_ = encryption_config;
   }
   void set_media_time(int64_t media_time) { media_time_ = media_time; }
+  void set_default_sample_duration(uint32_t duration) {
+    default_sample_duration_ = duration;
+  }
 
  private:
   // Whether the stream is Audio or Video.
@@ -148,9 +154,12 @@ class StreamInfo {
   // codebooks.
   std::vector<uint8_t> codec_config_;
 
-  // Optional data required for preserving edit lists when repackaging an
+  // Optional data required for preserving media time when repackaging an
   // init segment alone.
   int64_t media_time_ = 0;
+  // Optional data required for preserving default sample duration when repackaging an
+  // init segment alone.
+  uint32_t default_sample_duration_ = 0;
 
   // Not using DISALLOW_COPY_AND_ASSIGN here intentionally to allow the compiler
   // generated copy constructor and assignment operator. Since the extra data is

--- a/packager/media/base/stream_info.h
+++ b/packager/media/base/stream_info.h
@@ -124,9 +124,7 @@ class StreamInfo {
   void set_encryption_config(const EncryptionConfig& encryption_config) {
     encryption_config_ = encryption_config;
   }
-  void set_media_time(int64_t media_time) {
-    media_time_ = media_time;
-  }
+  void set_media_time(int64_t media_time) { media_time_ = media_time; }
 
  private:
   // Whether the stream is Audio or Video.

--- a/packager/media/formats/mp4/mp4_media_parser.cc
+++ b/packager/media/formats/mp4/mp4_media_parser.cc
@@ -590,6 +590,11 @@ bool MP4MediaParser::ParseMoov(BoxReader* reader) {
           num_channels, sampling_frequency, seek_preroll_ns, codec_delay_ns,
           max_bitrate, avg_bitrate, track->media.header.language.code,
           is_encrypted));
+
+      const EditList& edit_list = track->edit.list;
+      if (edit_list.edits.size() == 1u) {
+        streams.back()->set_media_time(edit_list.edits.front().media_time);
+      }
     }
 
     if (samp_descr.type == kVideo) {

--- a/packager/media/formats/mp4/mp4_media_parser.cc
+++ b/packager/media/formats/mp4/mp4_media_parser.cc
@@ -598,7 +598,8 @@ bool MP4MediaParser::ParseMoov(BoxReader* reader) {
 
       for (const auto& trex : moov_->extends.tracks) {
         if (trex.track_id == track->header.track_id) {
-          streams.back()->set_default_sample_duration(trex.default_sample_duration);
+          streams.back()->set_default_sample_duration(
+              trex.default_sample_duration);
           break;
         }
       }
@@ -777,7 +778,8 @@ bool MP4MediaParser::ParseMoov(BoxReader* reader) {
 
       for (const auto& trex : moov_->extends.tracks) {
         if (trex.track_id == track->header.track_id) {
-          video_stream_info->set_default_sample_duration(trex.default_sample_duration);
+          video_stream_info->set_default_sample_duration(
+              trex.default_sample_duration);
           break;
         }
       }

--- a/packager/media/formats/mp4/mp4_media_parser.cc
+++ b/packager/media/formats/mp4/mp4_media_parser.cc
@@ -595,6 +595,13 @@ bool MP4MediaParser::ParseMoov(BoxReader* reader) {
       if (edit_list.edits.size() == 1u) {
         streams.back()->set_media_time(edit_list.edits.front().media_time);
       }
+
+      for (const auto& trex : moov_->extends.tracks) {
+        if (trex.track_id == track->header.track_id) {
+          streams.back()->set_default_sample_duration(trex.default_sample_duration);
+          break;
+        }
+      }
     }
 
     if (samp_descr.type == kVideo) {
@@ -766,6 +773,13 @@ bool MP4MediaParser::ParseMoov(BoxReader* reader) {
       const EditList& edit_list = track->edit.list;
       if (edit_list.edits.size() == 1u) {
         video_stream_info->set_media_time(edit_list.edits.front().media_time);
+      }
+
+      for (const auto& trex : moov_->extends.tracks) {
+        if (trex.track_id == track->header.track_id) {
+          video_stream_info->set_default_sample_duration(trex.default_sample_duration);
+          break;
+        }
       }
 
       streams.push_back(video_stream_info);

--- a/packager/media/formats/mp4/mp4_media_parser.cc
+++ b/packager/media/formats/mp4/mp4_media_parser.cc
@@ -758,6 +758,11 @@ bool MP4MediaParser::ParseMoov(BoxReader* reader) {
                                              pssh_raw_data.size());
       }
 
+      const EditList& edit_list = track->edit.list;
+      if (edit_list.edits.size() == 1u) {
+        video_stream_info->set_media_time(edit_list.edits.front().media_time);
+      }
+
       streams.push_back(video_stream_info);
     }
   }

--- a/packager/media/formats/mp4/mp4_muxer.cc
+++ b/packager/media/formats/mp4/mp4_muxer.cc
@@ -264,6 +264,9 @@ Status MP4Muxer::DelayInitializeMuxer() {
     TrackExtends& trex = moov->extends.tracks[i];
     trex.track_id = trak.header.track_id;
     trex.default_sample_description_index = 1;
+    if (stream->get_default_sample_duration() != 0) {
+      trex.default_sample_duration = stream->get_default_sample_duration();
+    }
 
     bool generate_trak_result = false;
     switch (stream->stream_type()) {

--- a/packager/media/formats/mp4/mp4_muxer.cc
+++ b/packager/media/formats/mp4/mp4_muxer.cc
@@ -293,6 +293,11 @@ Status MP4Muxer::DelayInitializeMuxer() {
       entry.media_time = edit_list_offset_.value();
       entry.media_rate_integer = 1;
       trak.edit.list.edits.push_back(entry);
+    } else if (stream->media_time() > 0) {
+      EditListEntry entry;
+      entry.media_time = stream->media_time();
+      entry.media_rate_integer = 1;
+      trak.edit.list.edits.push_back(entry);
     }
 
     if (stream->is_encrypted() && options().mp4_params.include_pssh_in_stream) {

--- a/packager/media/formats/mp4/mp4_muxer.cc
+++ b/packager/media/formats/mp4/mp4_muxer.cc
@@ -293,7 +293,7 @@ Status MP4Muxer::DelayInitializeMuxer() {
       entry.media_time = edit_list_offset_.value();
       entry.media_rate_integer = 1;
       trak.edit.list.edits.push_back(entry);
-    } else if (stream->media_time() > 0) {
+    } else if (stream->media_time() != 0) {
       EditListEntry entry;
       entry.media_time = stream->media_time();
       entry.media_rate_integer = 1;


### PR DESCRIPTION
Goes after https://github.com/Pluto-tv/shaka-packager-live/pull/27